### PR TITLE
Feature/blake3 salt included

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.65.0
+      - uses: dtolnay/rust-toolchain@1.66.0
       - run: cargo build --verbose
 
   clippy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,12 @@ exclude = [".idea/*"]
 [dependencies]
 serde = { version = "1.0.204", features = ["derive"] }
 serde_bytes = "0.11.15"
-ed25519-dalek = { version = "2.1.1", features = [
-    "rand_core",
-    "pkcs8",
-    "serde",
-] }
+ed25519-dalek = { version = "2.1.1", features = ["rand_core", "zeroize", "pkcs8", "serde", "digest"] }
 bincode = "1.3.3"
 ring = "0.17.8"
 rand = "0.8.5"
-sha3 = "0.10.8"
+blake3 = "1.5.4"
 thiserror = "1.0.63"
 chrono = "0.4.38"
+generic-array = "1.1.0"
+typenum = "1.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "bitwark"
-version = "1.2.3"
+version = "2.0.0"
 authors = ["Ivan Ermolaev <ermolaevym@gmail.com>"]
 edition = "2021"
-license = "MIT OR BSD-3-Clause"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "Empowering secure digital interactions with robust binary token management and dynamic rolling keys"
 homepage = "https://github.com/versolid/bitwark"

--- a/README.md
+++ b/README.md
@@ -12,18 +12,56 @@
 ---
 
 ## 🚀 Introduction
-Bitwark implements binary JSON Web Tokens as a bandwidth-efficient alternative to standard JWTs, while integrating automated key rotation and salting to dynamically strengthen cryptographic protections.
+**Bitwark** is your go-to library for enhancing security in Rust applications. It offers a streamlined, bandwidth-friendly version of JSON Web Tokens (JWTs) and includes features like automatic key rotation and data salting to bolster your app's defenses.
 
 ### 🔐 Key Features:
 
-* *Binary Signed Payload*: Compact binary encoding of signed payload (similar to JWT)
-* *Default Cryptography*: Bitwark by default uses EdDSA for signing and verifying with SHA3-384 (EdDSA_SHA3-384).
-* *Rotation*: Easily rotate keys and salts, ensuring your application adapts to the dynamic security landscape.
-* *Salting*: Random data injection to increase entropy and slow brute force attacks.
-* *Lightweight*: Minimal overhead, ensuring optimal performance even in high-throughput scenarios.
+* **Compact Tokens**: Uses binary format for signed payloads, saving space compared to traditional JWTs.
+* **Advanced Encryption**: Employs EdDSA with Blake3 for robust signing and verification out of the box.
+* **Dynamic Key Rotation**: Simplifies the process to update keys and salts, keeping your security measures up-to-date.
+* **Enhanced Security with Salting**: Adds random data to payloads, making it tougher for attackers to crack.
+* **Performance Optimized**: Designed to be lightweight, ensuring your applications run smoothly under pressure.
 
 ## 🛠️ Getting Started
-Embark on a secure journey with Bitwark by leveraging the following functionality in your Rust applications:
+Explore the secure features of Bitwark for your Rust applications:
+#### All-in-One Example (Alternative to JWT)
+Imagine you have a structure you wish to sign and send back to the user:
+```rust
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Token {
+    pub user_id: u32,
+    pub permissions: Vec<String>,
+}
+```
+First, generate a key that expires after 10 minutes, though you can set it for days, months, or years as needed. For a non-expiring key, simply use `EdDsaKey::generate()`:
+```rust
+let exp_key = AutoExpiring::<EdDsaKey>::generate(
+    Duration::minutes(10)
+).unwrap();
+```
+Next, create the token. `SaltyExpiringSigned` adds a default 64-byte salt and includes an expiration time:
+```rust
+let token_object = Token { user_id: 123, permissions: vec!["Read".to_string(), "Write".to_string()] };
+
+let token = SaltyExpiringSigned::<Token>::new(
+    chrono::Duration::minutes(10),
+    token_object
+).unwrap();
+```
+Finally, prepare the token for the client. You can return it as bytes or convert it to base64:
+```rust
+let token_bytes: Vec<u8> = token.encode_and_sign(&*exp_key).unwrap();
+```
+When the user provides this token to your service, verifying it is straightforward:
+```rust
+let token = SaltyExpiringSigned::<Token>::decode_and_verify(&token_bytes, &*exp_key).unwrap();
+
+if token.permissions.contains(&String::from("Read")) {
+    // Proceed with the user's request
+}
+```
+
+### More Comprehensive Examples Follow
 #### Signed Payload decoded as binary (alternative to JWT)
 ```rust
 use bitwark::{

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [actions]: https://github.com/versolid/bitwark/actions?query=branch%3Amain
 [Latest Version]: https://img.shields.io/crates/v/bitwark.svg
 [crates.io]: https://crates.io/crates/bitwark
-[bitwark: rustc 1.65+]: https://img.shields.io/badge/bitwark-rustc_1.65+-lightgray.svg
+[bitwark: rustc 1.66+]: https://img.shields.io/badge/bitwark-rustc_1.65+-lightgray.svg
 [Rust 1.65]: https://blog.rust-lang.org/2021/10/21/Rust-1.65.0.html
 
 **Provides robust security for Rust applications through compact binary tokens and automated cryptographic defenses.**

--- a/README.md
+++ b/README.md
@@ -191,18 +191,17 @@ assert!(decoded_result.is_ok());
 ```
 
 ## 💡 Motivation
-In an era where data security is paramount, Bitwark aims to offer developers a toolbox for crafting secure digital interactions without compromising on performance or ease of use. Lightweight binary JWT tokens minimize bandwidth usage, while key rotation and salt functionalities amplify security, ensuring your applications are not just secure, but also efficient and reliable.
+In today's digital landscape, security must not come at the expense of performance. Bitwark addresses this challenge by:
+* Providing lightweight, bandwidth-efficient tokens for data exchange.
+* Offering robust security features like automatic key rotation and salting to adapt to evolving threats.
 
 ## 🌱 Contribution
 ### Be a Part of Bitwark’s Journey!
-Contributors are the backbone of open-source projects, and Bitwark warmly welcomes everyone who’s eager to contribute to the realms of binary security!
-
-#### 🎗 How to Contribute:
-
-* 🧠 Propose Ideas: Share enhancement ideas or report bugs through Issues.
-* 🛠 Code Contributions: Submit a Pull Request with new features, enhancements, or bug fixes.
-* 📚 Improve Documentation: Help us make our documentation comprehensive and user-friendly.
-* 💬 Community Interaction: Join discussions and provide feedback to help make Bitwark better.
+We believe in the power of community, and Bitwark thrives on contributions from developers like you:
+* **Propose Ideas**: Found a bug or have an idea? Open an **Issue!**
+* **Code Contributions**: Enhance Bitwark by submitting **Pull Requests** with your code.
+* **Documentation**: Help us keep our documentation clear and helpful.
+* **Engage**: Participate in community discussions to shape Bitwark's future.
 
 ## 📜 License
-Bitwark is open-source software, freely available under the MIT License or BSD-3-Clause.
+**Bitwark** is licensed under the MIT License or Apache-2.0 to ensure it remains accessible for all developers.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,15 +1,20 @@
+use ed25519_dalek::SignatureError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum BwError {
-    #[error("Token is expired")]
+    #[error("token is expired")]
     Expired,
-    #[error("Invalid signature")]
+    #[error("invalid signature")]
     InvalidSignature,
-    #[error("Invalid token format")]
+    #[error("invalid token format")]
     InvalidTokenFormat,
-    #[error("Failed to generate a salt")]
+    #[error("failed to generate a salt")]
     FailedSaltGeneration,
-    #[error("Incorrect timestamp")]
+    #[error("incorrect timestamp")]
     IncorrectTimestamp,
+    #[error("invalid salt length: expected {expected} bytes but got {actual} bytes")]
+    InvalidSaltLength { expected: usize, actual: usize },
+    #[error(transparent)]
+    InvalidDigest(#[from] SignatureError)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ## Signed Payload decoded as binary (alternative to JWT)
 //! ```
-//! # use bitwark::{exp::AutoExpiring, signed_exp::ExpiringSigned, salt::Salt64, keys::{ed::EdDsaKey}};
+//! # use bitwark::{exp::AutoExpiring, signed_exp::ExpiringSigned, salt::{Salt64,SaltInfo}, keys::{ed::EdDsaKey}};
 //! # use serde::{Serialize, Deserialize};
 //! # use chrono::Duration;
 //! #[derive(Serialize,Deserialize, Clone)]
@@ -34,12 +34,12 @@
 //! let token = ExpiringSigned::<Claims>::new(Duration::seconds(120), claims).unwrap();
 //!
 //! // Create a binary encoding of the token, signed with the key and salt.
-//! let signed_token_bytes = token.encode_and_sign_salted(&exp_salt, &*exp_key)
+//! let signed_token_bytes = token.encode_and_sign_salted(exp_salt.as_bytes(), &*exp_key)
 //!     .expect("Failed to sign token");
 //!
 //! // Decode the token and verify its signature and validity.
 //! let decoded_token = ExpiringSigned::<Claims>::decode_and_verify_salted(
-//!     &signed_token_bytes, &exp_salt, &*exp_key
+//!     &signed_token_bytes, exp_salt.as_bytes(), &*exp_key
 //! ).expect("Failed to decode a token");
 //! assert_eq!(2, decoded_token.permissions.len(), "Failed to find 2 permissions");
 //! ```
@@ -119,7 +119,7 @@
 //! Example with Rotation (Assuming `Expiring` is a structure which utilizes the `Rotation` trait):
 //!
 //! ```
-//! use bitwark::{salt::Salt64, exp::AutoExpiring, keys::ed::EdDsaKey, Rotation, Generator};
+//! use bitwark::{salt::{Salt64, SaltInfo}, exp::AutoExpiring, keys::ed::EdDsaKey, Rotation, Generator};
 //! use bitwark::payload::SignedPayload;
 //! use chrono::Duration;
 //!
@@ -140,10 +140,10 @@
 //! let payload = SignedPayload::<String>::new("Hello, world!".to_string());
 //!
 //! // Combine the message and a special code (signature) into one piece.
-//! let signature_bytes = payload.encode_and_sign_salted(&expiring_salt, &*key).expect("Failed to encode");
+//! let signature_bytes = payload.encode_and_sign_salted(expiring_salt.as_bytes(), &*key).expect("Failed to encode");
 //!
 //! // Separate the message and the signature, checking they're valid.
-//! let decoded_result = SignedPayload::<String>::decode_and_verify_salted(&signature_bytes, &expiring_salt, &*key);
+//! let decoded_result = SignedPayload::<String>::decode_and_verify_salted(&signature_bytes, expiring_salt.as_bytes(), &*key);
 //! assert!(decoded_result.is_ok());
 //! ```
 //!


### PR DESCRIPTION
- Changed hash algorithm from SHA3 to Blake2 for improved performance.
- Fixed issue with redundant double hashing; now using prehashed mechanism.
- Updated SaltN from Vec<u8> to fixed-size array [u8; N] for consistency and efficiency.
- Implemented SaltyExpiringSigned struct to automatically include salt in encoded bytes.